### PR TITLE
Patch Release 1.0.1: Remove hardcoded x-api-key header and instead use client id from credentials used to create the access token.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding='utf-8') as fh:
 
 setuptools.setup(
     name="pdfservices-sdk",
-    version="1.0.0",
+    version="1.0.1",
     author='Adobe Document Services',
     author_email='Adobe',
     license='Apache2',

--- a/src/adobe/pdfservices/operation/internal/auth/authenticator.py
+++ b/src/adobe/pdfservices/operation/internal/auth/authenticator.py
@@ -20,3 +20,7 @@ class Authenticator(ABC):
     @abstractmethod
     def refresh_token(self):
         pass
+
+    @abstractmethod
+    def get_api_key(self):
+        pass

--- a/src/adobe/pdfservices/operation/internal/auth/jwt_authenticator.py
+++ b/src/adobe/pdfservices/operation/internal/auth/jwt_authenticator.py
@@ -48,7 +48,7 @@ class JwtAuthenticator(Authenticator):
         return int((datetime.now() - self.token.expired_at).seconds / 60)
 
     def refresh_token(self):
-        jwt_token = self.prepare_jwt()
+        jwt_token = self._prepare_jwt()
         url = "{jwt_endpoint}/{jwt_uri_suffix}".format(
             jwt_endpoint=self.service_account_configuration.ims_base_uri,
             jwt_uri_suffix=ServiceConstants.JWT_URI_SUFFIX
@@ -66,6 +66,9 @@ class JwtAuthenticator(Authenticator):
         except Exception:
             raise SdkException("Exception in fetching access token", sys.exc_info())
         return self.token
+
+    def get_api_key(self):
+        return self.service_account_configuration.client_id
 
     def handle_ims_failure(self, response):
         self._logger.error(
@@ -86,7 +89,7 @@ class JwtAuthenticator(Authenticator):
                                  error_message=content.get("error_description", None),
                                  request_tracking_id=ResponseUtil.get_request_tracking_id_from_response(response, True))
 
-    def prepare_jwt(self):
+    def _prepare_jwt(self):
         audience = "{base_uri}/{audience_suffix}{client_id}".format(
             base_uri=self.service_account_configuration.ims_base_uri,
             audience_suffix=ServiceConstants.JWT_AUDIENCE_SUFFIX,

--- a/src/adobe/pdfservices/operation/internal/http/http_client.py
+++ b/src/adobe/pdfservices/operation/internal/http/http_client.py
@@ -34,6 +34,7 @@ def process_request(http_request: HttpRequest, success_status_codes: List,
         # get token and append auth header
         access_token = http_request.authenticator.session_token().access_token
         http_request.headers[DefaultHeaders.AUTHORIZATION_HEADER_NAME] = "Bearer " + access_token
+        http_request.headers[DefaultHeaders.X_API_KEY_HEADER_NAME] = http_request.authenticator.get_api_key()
 
     # retry the request if it fails with 401 and specific error code
     while (True):
@@ -51,9 +52,7 @@ def _append_default_headers(headers: dict):
     # Set SDK Info header
     headers[DefaultHeaders.DC_APP_INFO_HEADER_KEY] = "{lang}-{name}-{version}".format(lang="python",
                                                                                       name='pdfservices-sdk',
-                                                                                      version='1.0.0')
-    # Set default API Key
-    headers[DefaultHeaders.X_API_KEY_HEADER_NAME] = DefaultHeaders.X_API_KEY_HEADER_VALUE
+                                                                                      version='1.0.1')
     headers[DefaultHeaders.ACCEPT_HEADER_NAME] = DefaultHeaders.JSON_TXT_CONTENT_TYPE
 
 

--- a/src/adobe/pdfservices/operation/internal/http/request_header_const.py
+++ b/src/adobe/pdfservices/operation/internal/http/request_header_const.py
@@ -19,5 +19,4 @@ class DefaultHeaders:
     DC_APP_INFO_HEADER_KEY = "x-api-app-info"
     X_DCSDK_OPS_INFO_HEADER_NAME = "x-dcsdk-ops-info"
     SESSION_TOKEN_REQUEST_ID_HEADER_KEY = "X-DEBUG-ID"
-    X_API_KEY_HEADER_VALUE = "AdobeDCPlatformExtractKey"
     JSON_TXT_CONTENT_TYPE = "application/json, text/plain, */*"


### PR DESCRIPTION
 ## Description
Patch Release 1.0.1: Remove hardcoded x-api-key header and instead use client id from credentials used to create the access token.

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.