### PR TITLE
loose the request deps version from 2.32 to 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests~=2.31.0
+requests>=2.32.0,<=3.0.0dev
 setuptools~=69.5.1
 sphinx~=7.3.7
 sphinx-rtd-theme~=2.0.0


### PR DESCRIPTION
## Description
- Loose the request dependencies version from 2.32 to 3.0.0, that will help mitigating security issues of the library in the future

## Related Issue
<!--- if applicable -->

## Tasks
<!--- These tasks need to be done in order to get the PR merged, please mark with `x` if done or if they are not applicable to you or the change -->

- [ ] I have signed the [CLA](http://adobe.github.io/cla.html).
- [ ] I have written tests and verified that they fail without my change.